### PR TITLE
O3-1474: Fix the advanced option checkboxes

### DIFF
--- a/packages/esm-admin-openconceptlab-app/src/subscription/subscription.component.tsx
+++ b/packages/esm-admin-openconceptlab-app/src/subscription/subscription.component.tsx
@@ -46,11 +46,11 @@ const Subscription: React.FC = () => {
     setToken(event.target.value);
   }, []);
 
-  const handleChangeValidationType = useCallback((checked: boolean) => {
+  const handleChangeValidationType = useCallback((event, { checked, id }) => {
     setValidationType(checked ? 'NONE' : 'FULL');
   }, []);
 
-  const handleChangeSubscriptionType = useCallback((checked: boolean) => {
+  const handleChangeSubscriptionType = useCallback((event, { checked, id }) => {
     setIsSubscribedToSnapshot(checked);
   }, []);
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
The checkboxes in advanced options were not working after the carbon v11 upgrade. The error was caused by a change in `onChange` prop signature [(v11.md#checkbox)](https://github.com/carbon-design-system/carbon/blob/main/docs/migration/) . Fixed the issue by updating the handlers.
<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Issue

https://issues.openmrs.org/browse/O3-1474
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/O3-123").
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
