### PR TITLE
O3-1465: Disable the subscribe to snapshot option when version is provided

### DIFF
--- a/packages/esm-admin-openconceptlab-app/src/utils.ts
+++ b/packages/esm-admin-openconceptlab-app/src/utils.ts
@@ -1,0 +1,28 @@
+const NUMBER_OF_SLASHES_AFTER_BASE_URL = 5;
+
+/*
+ * This checks if collection version has been passed to subscription url by checking number of forward slashes after base url
+ * If the number is 5, such as with https://api.openconceptlab.org/users/username/collections/collectionname/v1.0
+ * that means collection version was passed and isVersionDefinedInUrl() will return true
+ * Also returns false if the string is not a valid URL
+ */
+export const isVersionDefinedInUrl = (subscriptionUrl: string) => {
+  if (subscriptionUrl.endsWith('/')) {
+    subscriptionUrl = subscriptionUrl.substring(0, subscriptionUrl.lastIndexOf('/'));
+  }
+
+  let url;
+  try {
+    url = new URL(subscriptionUrl);
+  } catch (e) {
+    return false;
+  }
+
+  let subUrlAfterBaseUrl = url.pathname;
+  let count = subUrlAfterBaseUrl.length - subUrlAfterBaseUrl.replace(/[\/\\]/g, '').length;
+  if (count == NUMBER_OF_SLASHES_AFTER_BASE_URL) {
+    return true;
+  } else {
+    return false;
+  }
+};

--- a/packages/esm-admin-openconceptlab-app/src/utils.ts
+++ b/packages/esm-admin-openconceptlab-app/src/utils.ts
@@ -18,8 +18,7 @@ export const isVersionDefinedInUrl = (subscriptionUrl: string) => {
     return false;
   }
 
-  let subUrlAfterBaseUrl = url.pathname;
-  let count = subUrlAfterBaseUrl.length - subUrlAfterBaseUrl.replace(/[\/\\]/g, '').length;
+  let count = url.pathname.match(/\//g)?.length ?? 0;
   if (count == NUMBER_OF_SLASHES_AFTER_BASE_URL) {
     return true;
   } else {

--- a/packages/esm-admin-openconceptlab-app/translations/en.json
+++ b/packages/esm-admin-openconceptlab-app/translations/en.json
@@ -37,6 +37,7 @@
   "previousImportsFetchError": "Error occured while fetching the imports",
   "result": "Result:",
   "setupSubscription": "Setup Subscription",
+  "snapshotDisabledError": "You cannot subscribe to a SNAPSHOT if you've provided the collection version",
   "startedOn": "Started on",
   "status": "Status",
   "subscribeButton": "Save changes",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
The UI should not allow choosing a snapshot version of a OCL subscription is the version is already defined. So the URL is validated and the subscribeToSnapshot checkbox is enabled/disabled according to that. 
Referred to [this](https://github.com/openmrs/openmrs-module-openconceptlab/blob/caed41af5f0b32d398cce1b43a10f5b4a57e73d9/owa/app/js/subscription/subscription.controller.js#L59) when working on this issue.

## Screenshots

When the version is given with the URL:
<img width="80%" alt="image" src="https://user-images.githubusercontent.com/27498587/186966981-6023db42-173b-436b-ad01-1faef8655e09.png">

When the version is not provided:
<img width="80%" alt="image" src="https://user-images.githubusercontent.com/27498587/186967086-22572c54-9cd7-4e20-a1b8-8958a541dc53.png">


<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Issue

https://issues.openmrs.org/browse/O3-1465
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/O3-123").
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
