### PR TITLE
O3-1488: Display loading state when uploading zip file

### DIFF
--- a/packages/esm-admin-openconceptlab-app/src/import/import.component.tsx
+++ b/packages/esm-admin-openconceptlab-app/src/import/import.component.tsx
@@ -8,6 +8,8 @@ import {
   FileUploaderSkeleton,
   Form,
   Grid,
+  InlineLoading,
+  Stack,
   SkeletonText,
 } from '@carbon/react';
 import React, { useCallback, useEffect, useState } from 'react';
@@ -19,6 +21,7 @@ const Import: React.FC = () => {
   const { t } = useTranslation();
   const [isSubscriptionAvailable, setIsSubscriptionAvailable] = useState(false);
   const [file, setFile] = useState<File>();
+  const [isFileUploading, setIsFileUploading] = useState(false);
 
   const { data: subscription, isLoading, isError } = useSubscription();
 
@@ -80,10 +83,12 @@ const Import: React.FC = () => {
 
   const handleImportWithFile = useCallback(
     async (evt: React.FormEvent<HTMLFormElement>) => {
+      setIsFileUploading(true);
       evt.preventDefault();
       evt.stopPropagation();
 
       if (!file) {
+        setIsFileUploading(false);
         showNotification({
           kind: 'error',
           description: t('noFileSelected', 'No file selected'),
@@ -96,11 +101,13 @@ const Import: React.FC = () => {
 
       if (response.status === 201) {
         setFile(null);
+        setIsFileUploading(false);
         showNotification({
           kind: 'success',
           description: t('importSuccess', 'Import started successfully'),
         });
       } else {
+        setIsFileUploading(false);
         showNotification({
           kind: 'error',
           description: t('importFailed', 'Import failed'),
@@ -178,9 +185,12 @@ const Import: React.FC = () => {
               style={{ marginBottom: '1.5rem' }}
             />
           )}
-          <Button kind="primary" type="submit">
-            {t('importFromFile', 'Import from file')}
-          </Button>
+          <Stack gap={6} orientation="horizontal">
+            <Button kind="primary" type="submit">
+              {t('importFromFile', 'Import from file')}
+            </Button>
+            {isFileUploading && <InlineLoading description={t('uploading', 'Uploading...')} />}
+          </Stack>
         </Form>
       </Column>
     </Grid>

--- a/packages/esm-admin-openconceptlab-app/translations/en.json
+++ b/packages/esm-admin-openconceptlab-app/translations/en.json
@@ -47,5 +47,6 @@
   "subscriptionUrl": "Subscription URL",
   "unsubscribe": "Unsubscribe",
   "unsubscribeButton": "Unsubscribe",
-  "unsubscribeInfo": "If you unsubscribe, no concepts will be deleted nor changed. All information about subscription will be deleted from your system."
+  "unsubscribeInfo": "If you unsubscribe, no concepts will be deleted nor changed. All information about subscription will be deleted from your system.",
+  "uploading": "Uploading..."
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
When importing concepts by uploading a zip file, a loading message will be displayed until the file upload is completed
<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots

<img width="612" alt="image" src="https://user-images.githubusercontent.com/27498587/187529181-afa7a34b-fc44-4cec-ad13-4ff6313d452b.png">

<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Issue

https://issues.openmrs.org/browse/O3-1488
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/O3-123").
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
