### PR TITLE
(fix) Adjust System Admin page styles for responsiveness

### DIFF
--- a/packages/esm-system-admin-app/src/dashboard/index.component.tsx
+++ b/packages/esm-system-admin-app/src/dashboard/index.component.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { ExtensionSlot } from '@openmrs/esm-framework';
-
-import { LinkCard } from './card.component';
 import styles from './index.scss';
 
 export const SystemAdministrationDashboard = () => {

--- a/packages/esm-system-admin-app/src/dashboard/index.scss
+++ b/packages/esm-system-admin-app/src/dashboard/index.scss
@@ -4,6 +4,7 @@
 
 .systemAdminPage {
   background-color: $ui-02;
+
   .breadCrumbsContainer {
     nav {
       background-color: $ui-01;
@@ -11,15 +12,22 @@
   }
 
   .cardsView {
-    display: flex;
     background-color: $ui-01;
-    padding: 2rem 1rem;
-    margin-top: 2rem;
+    padding-top: 3rem;
   }
 
   .cardLinks {
+    margin-left: 1rem;
+    margin-right: 1rem;
+
     display: flex;
-    width: 100%;
+    flex: auto;
+    flex-wrap: wrap;
+
+    div {
+      margin-top: 1rem;
+    }
+
     :global(.cds--link) {
       height: 8rem;
       width: 14rem;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

<!--
Required.
Please describe what problems your PR addresses.
-->

This PR fixes two things on the System Administration Page:

![Current system administration page](https://github.com/openmrs/openmrs-esm-admin-tools/assets/52504170/ac2f5abb-f8a3-43fd-9bb7-99d6a5be97ac)

1. I'm not sure why we have a white bar between the breadcrumbs and the cards, but it's a result of mixing margins and padding.
2. The current styles do not properly down-scale for smaller screens.

With this PR we get basically an identical look at small desktop:

![New state](https://github.com/openmrs/openmrs-esm-admin-tools/assets/52504170/a995f804-f37e-414b-a14f-265dcdf6dfa9)

But the items "wrap" as the screen shrinks:

![New state, small screen](https://github.com/openmrs/openmrs-esm-admin-tools/assets/52504170/839d9150-77df-4417-b5eb-586617f68209)