### PR TITLE
(fix) Fix typo in component name in `routes.json`

### DIFF
--- a/packages/esm-system-admin-app/src/routes.json
+++ b/packages/esm-system-admin-app/src/routes.json
@@ -8,7 +8,7 @@
     {
       "name": "system-administration-app-menu-link",
       "slot": "app-menu-slot",
-      "component": "systemADminAppMenuLink"
+      "component": "systemAdminAppMenuLink"
     },
     {
       "name": "system-admin-page-link",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

Fixes a typo in the `component` property inside `routes.json`. 