### PR TITLE
(fix) Exports should reference the result of getSync/getAsync

### DIFF
--- a/packages/esm-admin-openconceptlab-app/src/index.ts
+++ b/packages/esm-admin-openconceptlab-app/src/index.ts
@@ -14,6 +14,6 @@ export function startupApp() {
   defineConfigSchema(moduleName, configSchema);
 }
 
-export const root = () => getAsyncLifecycle(() => import('./root.component'), options);
+export const root = getAsyncLifecycle(() => import('./root.component'), options);
 
-export const adminOclCardLink = () => getAsyncLifecycle(() => import('./admin-ocl-card-link.component'), options);
+export const adminOclCardLink = getAsyncLifecycle(() => import('./admin-ocl-card-link.component'), options);


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

Named exports in `index.ts` should reference the result of `getSyncLifecycle`/`getAsyncLifecycle`.