### PR TITLE
(fix) Exports should reference the result of getSync / getAsync

### DIFF
--- a/packages/esm-system-admin-app/src/index.ts
+++ b/packages/esm-system-admin-app/src/index.ts
@@ -25,8 +25,12 @@ export function startupApp() {
 
 export const root = () => getAsyncLifecycle(() => import('./root.component'), options);
 
-export const systemAdminAppMenuLink = () =>
-  getAsyncLifecycle(() => import('./system-admin-app-menu-link.component'), options);
+export const systemAdminAppMenuLink = getAsyncLifecycle(
+  () => import('./system-admin-app-menu-link.component'),
+  options,
+);
 
-export const legacySystemAdminPageCardLink = () =>
-  getAsyncLifecycle(() => import('./dashboard/legacy-admin-page-link.component'), options);
+export const legacySystemAdminPageCardLink = getAsyncLifecycle(
+  () => import('./dashboard/legacy-admin-page-link.component'),
+  options,
+);


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

Fixes an issue where frontend modules in the `esm-system-admin` aren't loading in the UI. The root cause is that the named exports for the components in the app entry point (`src/index.ts`) don't export the result of `getAsyncLifecycle` and `getSyncLifecycle`. This PR fixes those exports so that they return the expected values.
