### PR TITLE
(chore) O3-2628: Reduce timeout to 15 minutes in E2E test CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
     env:
       TURBO_API: 'http://127.0.0.1:9080'
       TURBO_TOKEN: ${{ secrets.TURBO_SERVER_TOKEN }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,9 +11,9 @@ on:
 jobs:
   main:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
-    steps:
       - name: Checkout repo
+    timeout-minutes: 15
+    steps:
         uses: actions/checkout@v3
 
       - name: Copy test environment variables

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,8 +11,9 @@ on:
 jobs:
   main:
     runs-on: ubuntu-latest
-      - name: Checkout repo
     timeout-minutes: 15
+      - name: Checkout repo
+    
     steps:
         uses: actions/checkout@v3
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

This PR reduces the `timeout` value from 1 hour to 15 minutes in the E2E test CI workflow.

## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->

## Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/O3-123").
-->

## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
