### PR TITLE
(chore) Loosen fhir2 dependency requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "ci:prepublish": "lerna publish from-package --no-git-reset --yes --dist-tag next",
     "release": "lerna version --no-git-tag-version",
     "verify": "turbo lint typescript test",
-    "prettier": "prettier --config prettier.config.js --write \"packages/**/*.{ts,tsx}\" \"e2e/**/*.ts\"",
+    "prettier": "prettier --config prettier.config.js --write \"packages/**/*.{ts,tsx}\" \"e2e/**/*.ts\" --list-different",
     "postinstall": "husky install",
     "test-e2e": "playwright test",
     "coverage": "yarn test --coverage",

--- a/packages/esm-admin-openconceptlab-app/src/root.component.tsx
+++ b/packages/esm-admin-openconceptlab-app/src/root.component.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Tab, Tabs, TabList, TabPanels, TabPanel } from '@carbon/react';
 import { useTranslation } from 'react-i18next';
-import { SWRConfig } from 'swr';
 import Import from './import/import.component';
 import PreviousImports from './previous-imports/previous-imports.component';
 import Subscription from './subscription/subscription.component';
@@ -10,29 +9,27 @@ import styles from './root.scss';
 const Root: React.FC = () => {
   const { t } = useTranslation();
   return (
-    <SWRConfig>
-      <main className={`omrs-main-content ${styles.main}`}>
-        <h3 className={styles.moduleHeader}>{t('moduleTitle', 'OCL Subscription Module')}</h3>
-        <Tabs>
-          <TabList aria-label="OCL tabs" className={styles.tabList} contained={true}>
-            <Tab>{t('subscription', 'Subscription')} </Tab>
-            <Tab>{t('import', 'Import')} </Tab>
-            <Tab>{t('previousImports', 'Previous Imports')} </Tab>
-          </TabList>
-          <TabPanels>
-            <TabPanel className={styles.tabPanel}>
-              <Subscription />
-            </TabPanel>
-            <TabPanel className={styles.tabPanel}>
-              <Import />
-            </TabPanel>
-            <TabPanel className={styles.tabPanel}>
-              <PreviousImports />
-            </TabPanel>
-          </TabPanels>
-        </Tabs>
-      </main>
-    </SWRConfig>
+    <main className={`omrs-main-content ${styles.main}`}>
+      <h3 className={styles.moduleHeader}>{t('moduleTitle', 'OCL Subscription Module')}</h3>
+      <Tabs>
+        <TabList aria-label="OCL tabs" className={styles.tabList} contained={true}>
+          <Tab>{t('subscription', 'Subscription')} </Tab>
+          <Tab>{t('import', 'Import')} </Tab>
+          <Tab>{t('previousImports', 'Previous Imports')} </Tab>
+        </TabList>
+        <TabPanels>
+          <TabPanel className={styles.tabPanel}>
+            <Subscription />
+          </TabPanel>
+          <TabPanel className={styles.tabPanel}>
+            <Import />
+          </TabPanel>
+          <TabPanel className={styles.tabPanel}>
+            <PreviousImports />
+          </TabPanel>
+        </TabPanels>
+      </Tabs>
+    </main>
   );
 };
 

--- a/packages/esm-system-admin-app/src/routes.json
+++ b/packages/esm-system-admin-app/src/routes.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.openmrs.org/routes.schema.json",
   "backendDependencies": {
-    "fhir2": "^1.2.0",
+    "fhir2": ">=1.2",
     "webservices.rest": "^2.2.0"
   },
   "extensions": [


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

This commit changes the [fhir2 backend module](https://github.com/openmrs/openmrs-module-fhir2) dependency version requirement from a caret range (^1.2.0) to a range that allows any version greater than or equal to 1.2 (>=1.2).

## Screenshots

Should fix this error on dev3:

![CleanShot 2024-03-01 at 12  34 35@2x](https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/84d332e2-417d-4bba-a877-f92dc19d5dba)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
