### PR TITLE
(chore) Require @openmrs/esm-framework 7.x in peerDependencies

### DIFF
--- a/packages/esm-admin-openconceptlab-app/package.json
+++ b/packages/esm-admin-openconceptlab-app/package.json
@@ -43,7 +43,7 @@
     "swr": "^2.2.5"
   },
   "peerDependencies": {
-    "@openmrs/esm-framework": "6.x",
+    "@openmrs/esm-framework": "7.x",
     "dayjs": "1.x",
     "react": "18.x",
     "react-dom": "18.x",

--- a/packages/esm-system-admin-app/package.json
+++ b/packages/esm-system-admin-app/package.json
@@ -41,7 +41,7 @@
     "swr": "^2.2.5"
   },
   "peerDependencies": {
-    "@openmrs/esm-framework": "6.x",
+    "@openmrs/esm-framework": "7.x",
     "dayjs": "1.x",
     "react": "18.x",
     "react-dom": "18.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4168,7 +4168,7 @@ __metadata:
     lodash-es: "npm:^4.17.21"
     swr: "npm:^2.2.5"
   peerDependencies:
-    "@openmrs/esm-framework": 6.x
+    "@openmrs/esm-framework": 7.x
     dayjs: 1.x
     react: 18.x
     react-dom: 18.x
@@ -4301,7 +4301,7 @@ __metadata:
     lodash-es: "npm:^4.17.21"
     swr: "npm:^2.2.5"
   peerDependencies:
-    "@openmrs/esm-framework": 6.x
+    "@openmrs/esm-framework": 7.x
     dayjs: 1.x
     react: 18.x
     react-dom: 18.x


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [ ] My work includes tests or is validated by existing tests.

## Summary

This PR updates the peerDependencies for all packages to require @openmrs/esm-framework `7.x` which is the latest version of Core.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
