### PR TITLE
O3-5860 Add Carbon packages to peerDependencies

### DIFF
--- a/packages/esm-admin-openconceptlab-app/package.json
+++ b/packages/esm-admin-openconceptlab-app/package.json
@@ -43,6 +43,8 @@
     "swr": "2.2.5"
   },
   "peerDependencies": {
+    "@carbon/icons-react": "^11.68.0",
+    "@carbon/react": "^1.92.1",
     "@openmrs/esm-framework": "10.x",
     "dayjs": "1.x",
     "react": "18.x",

--- a/packages/esm-patient-documents-admin-app/package.json
+++ b/packages/esm-patient-documents-admin-app/package.json
@@ -41,6 +41,8 @@
     "swr": "2.2.5"
   },
   "peerDependencies": {
+    "@carbon/icons-react": "^11.68.0",
+    "@carbon/react": "^1.92.1",
     "@openmrs/esm-framework": "10.x",
     "dayjs": "1.x",
     "react": "18.x",

--- a/packages/esm-reports-app/package.json
+++ b/packages/esm-reports-app/package.json
@@ -46,6 +46,8 @@
     "react-image-annotate": "^1.8.0"
   },
   "peerDependencies": {
+    "@carbon/icons-react": "^11.68.0",
+    "@carbon/react": "^1.92.1",
     "@openmrs/esm-framework": "10.x",
     "dayjs": "1.x",
     "i18next": "25.x",

--- a/packages/esm-system-admin-app/package.json
+++ b/packages/esm-system-admin-app/package.json
@@ -41,6 +41,8 @@
     "swr": "2.2.5"
   },
   "peerDependencies": {
+    "@carbon/icons-react": "^11.68.0",
+    "@carbon/react": "^1.92.1",
     "@openmrs/esm-framework": "10.x",
     "dayjs": "1.x",
     "react": "18.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4267,6 +4267,8 @@ __metadata:
     swr: "npm:2.2.5"
     vitest: "npm:^4.1.2"
   peerDependencies:
+    "@carbon/icons-react": ^11.68.0
+    "@carbon/react": ^1.92.1
     "@openmrs/esm-framework": 10.x
     dayjs: 1.x
     react: 18.x
@@ -4286,6 +4288,8 @@ __metadata:
     swr: "npm:2.2.5"
     vitest: "npm:^4.1.2"
   peerDependencies:
+    "@carbon/icons-react": ^11.68.0
+    "@carbon/react": ^1.92.1
     "@openmrs/esm-framework": 10.x
     dayjs: 1.x
     react: 18.x
@@ -4339,6 +4343,8 @@ __metadata:
     react-image-annotate: "npm:^1.8.0"
     vitest: "npm:^4.1.2"
   peerDependencies:
+    "@carbon/icons-react": ^11.68.0
+    "@carbon/react": ^1.92.1
     "@openmrs/esm-framework": 10.x
     dayjs: 1.x
     i18next: 25.x
@@ -4421,6 +4427,8 @@ __metadata:
     swr: "npm:2.2.5"
     vitest: "npm:^4.1.2"
   peerDependencies:
+    "@carbon/icons-react": ^11.68.0
+    "@carbon/react": ^1.92.1
     "@openmrs/esm-framework": 10.x
     dayjs: 1.x
     react: 18.x


### PR DESCRIPTION
## Requirements

* [x] This PR has a title that briefly describes the work done including the ticket number and a conventional commit label.
* [x] My work is based on the requirements described in O3-5860.
* [x] My work is validated by the existing project checks.

## Summary

Added `@carbon/react` and `@carbon/icons-react` to `peerDependencies` for the affected Admin Tools packages.

Updated:

* `esm-admin-openconceptlab-app`
* `esm-patient-documents-admin-app`
* `esm-reports-app`
* `esm-system-admin-app`

Updated `yarn.lock` accordingly.

## Screenshots

Not applicable — this is a dependency/package configuration change with no UI changes.

## Related Issue

O3-5860

## Other

No other changes.
